### PR TITLE
Modifications to be able to run `cargo test` on Reth primitives crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,6 +20,7 @@ rustflags = [
 target = "valida-unknown-baremetal-gnu"
 
 [target.valida-unknown-baremetal-gnu]
+runner = "/valida-toolchain/valida-runner.sh"
 linker = "/valida-toolchain/bin/ld.lld"
 rustflags = [
     "-C", "link-arg=/valida-toolchain/ValidaEntryPoint.o",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,6 +24,7 @@ runner = "/valida-toolchain/valida-runner.sh"
 linker = "/valida-toolchain/bin/ld.lld"
 rustflags = [
     "-C", "link-arg=/valida-toolchain/ValidaEntryPoint.o",
+    "-C", "link-arg=/valida-toolchain/io.o",
     "-C", "link-arg=--script=/valida-toolchain/valida.ld",
     "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libc.a",
     "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libm.a",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,3 +14,21 @@ rustflags = [
     # in line with Linux (whereas default for Windows is 1MB)
     "-Clink-arg=/STACK:10000000",
 ]
+
+
+[build]
+target = "valida-unknown-baremetal-gnu"
+
+[target.valida-unknown-baremetal-gnu]
+linker = "/valida-toolchain/bin/ld.lld"
+rustflags = [
+    "-C", "link-arg=/valida-toolchain/ValidaEntryPoint.o",
+    "-C", "link-arg=--script=/valida-toolchain/valida.ld",
+    "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libc.a",
+    "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libm.a",
+    "-C", "link-arg=--noinhibit-exec",
+]
+
+[env]
+CC_valida_unknown_baremetal_gnu = "/valida-toolchain/bin/clang"
+CFLAGS_valida_unknown_baremetal_gnu = "--sysroot=/valida-toolchain/ -isystem /valida-toolchain/include"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -602,7 +602,16 @@ tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = "0.6"
 tracy-client = "0.17.3"
 
-#[patch.crates-io]
+[patch.crates-io]
+wait-timeout = { git = "https://github.com/lita-xyz/wait-timeout", branch = "0.2.0-valida" }
+rusty-fork = { git = "https://github.com/lita-xyz/rusty-fork", branch = "0.3.0-valida" }
+is-terminal = { git = "https://github.com/lita-xyz/is-terminal", branch = "0.4.13-valida" }
+cc = { git = "https://github.com/lita-xyz/cc-rs.git", branch = "1.1.18-delendum" }
+blst = { git = "https://github.com/lita-xyz/blst.git", branch = "0.3.13-delendum" }
+c-kzg = { git = "https://github.com/lita-xyz/c-kzg-4844.git", branch = "1.0.3-delendum" }
+zstd-sys = { git = "https://github.com/lita-xyz/zstd-rs.git", branch = "zstd-sys-2.0.13-delendum" }
+proptest = { git = "https://github.com/lita-xyz/proptest", branch = "1.5.0-valida" }
+pprof = { git = "https://github.com/lita-xyz/pprof-rs", branch = "0.13.0-valida" }
 #alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
 #alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }
 #alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "a971b3a" }

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -13,6 +13,7 @@ default-run = "reth"
 workspace = true
 
 [dependencies]
+valida-rs = { git = "https://github.com/lita-xyz/valida-rs.git", branch = "main" }
 # reth
 reth-cli.workspace = true
 reth-ethereum-cli.workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,6 +12,7 @@ description = "Commonly used types in reth."
 workspace = true
 
 [dependencies]
+valida-rs = { git = "https://github.com/lita-xyz/valida-rs.git", branch = "main" }
 # reth
 reth-primitives-traits.workspace = true
 reth-ethereum-forks.workspace = true


### PR DESCRIPTION
This is a first step to be able to test the list of crates that we're interested in. The majority of the changes required were simply in various dependencies, to be able to compile them for Valida, since performing a `cargo test` build involves a lot more dependencies than a standard build.

Currently `cargo test` on Reth primitives is not passing, something to do with threading. But it does compile and reach the testing phase.